### PR TITLE
Migrate vue to use i18n hash instead of build timestamp.

### DIFF
--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -40,6 +40,7 @@
     "css-loader": "5.2.6",
     "css-minimizer-webpack-plugin": "3.0.1",
     "file-loader": "6.2.0",
+    "folder-hash": "4.0.1",
     "fork-ts-checker-webpack-plugin": "6.2.10",
     "html-webpack-plugin": "5.3.1",
     "jest": "27.0.4",

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -103,7 +103,10 @@
     "jest-serializer-vue": "<%= dependabotPackageJson.devDependencies['jest-serializer-vue'] %>",
     "jest-sonar-reporter": "<%= dependabotPackageJson.devDependencies['jest-sonar-reporter'] %>",
     "jest-vue-preprocessor": "<%= dependabotPackageJson.devDependencies['jest-vue-preprocessor'] %>",
+<%_ if (enableTranslation) { _%>
+    "folder-hash": "<%= dependabotPackageJson.devDependencies['folder-hash'] %>",
     "merge-jsons-webpack-plugin": "<%= dependabotPackageJson.devDependencies['merge-jsons-webpack-plugin'] %>",
+<%_ } _%>
     "mini-css-extract-plugin": "<%= dependabotPackageJson.devDependencies['mini-css-extract-plugin'] %>",
     "node-notifier": "<%= dependabotPackageJson.devDependencies['node-notifier'] %>",
     "numeral": "<%= dependabotPackageJson.devDependencies['numeral'] %>",

--- a/generators/client/templates/vue/src/main/webapp/app/constants.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/constants.ts.ejs
@@ -5,7 +5,6 @@
 export const VERSION = process.env.VERSION;
 // export const DEBUG_INFO_ENABLED: boolean = !!process.env.DEBUG_INFO_ENABLED;
 export const SERVER_API_URL = process.env.SERVER_API_URL;
-export const BUILD_TIMESTAMP = process.env.BUILD_TIMESTAMP;
 
 // Errors
 export const PROBLEM_BASE_URL = 'https://www.jhipster.tech/problem';

--- a/generators/client/templates/vue/src/main/webapp/app/locale/translation.service.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/locale/translation.service.ts.ejs
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import VueI18n from 'vue-i18n';
 import { Store } from 'vuex';
-import { BUILD_TIMESTAMP } from '@/constants';
 import dayjs from 'dayjs';
 
 export default class TranslationService {
@@ -18,7 +17,7 @@ export default class TranslationService {
     currentLanguage = newLanguage ? newLanguage : '<%= nativeLanguage %>';
     if (this.i18n && !this.i18n.messages[currentLanguage]) {
       this.i18n.setLocaleMessage(currentLanguage, {});
-      axios.get(`i18n/${currentLanguage}.json?buildTimestamp=${BUILD_TIMESTAMP}`).then((res) => {
+      axios.get(`i18n/${currentLanguage}.json?_=${I18N_HASH}`).then((res) => {
         if (res.data) {
           dayjs.locale(currentLanguage);
           this.i18n.setLocaleMessage(currentLanguage, res.data);

--- a/generators/client/templates/vue/src/main/webapp/app/shims-vue.d.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/shims-vue.d.ts.ejs
@@ -1,3 +1,7 @@
+<%_ if (enableTranslation) { _%>
+declare const I18N_HASH: string;
+
+<%_ } _%>
 declare module '*.vue' {
   import Vue from 'vue';
   export default Vue;

--- a/generators/client/templates/vue/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/vue/src/test/javascript/jest.conf.js.ejs
@@ -18,6 +18,11 @@ module.exports = {
   testMatch: ['<rootDir>/<%= CLIENT_TEST_SRC_DIR %>spec/**/@(*.)@(spec.ts)'],
   snapshotSerializers: ['<rootDir>/node_modules/jest-serializer-vue'],
   rootDir: '../../../',
+<%_ if (enableTranslation) { _%>
+  globals: {
+    I18N_HASH: 'generated_hash',
+  },
+<%_ } _%>
   coverageThreshold: {
     global: {
       statements: 80,

--- a/generators/client/templates/vue/webpack/dev.env.js.ejs
+++ b/generators/client/templates/vue/webpack/dev.env.js.ejs
@@ -8,7 +8,6 @@ const packageJson = require('./../package.json');
 module.exports = webpackMerge(prodEnv, {
   NODE_ENV: '"development"',
   SERVER_API_URL: '\'\'',
-  BUILD_TIMESTAMP: `'${new Date().getTime()}'`,
 <%_ if (buildToolUnknown) { _%>
   VERSION: `'${packageJson.version}'`,
 <%_ } else { _%>

--- a/generators/client/templates/vue/webpack/prod.env.js.ejs
+++ b/generators/client/templates/vue/webpack/prod.env.js.ejs
@@ -6,7 +6,6 @@ const packageJson = require('./../package.json');
 module.exports = {
   NODE_ENV: '"production"',
   SERVER_API_URL: '""',
-  BUILD_TIMESTAMP: `'${new Date().getTime()}'`,
 <%_ if (buildToolUnknown) { _%>
   VERSION: `'${packageJson.version}'`,
 <%_ } else { _%>

--- a/generators/client/templates/vue/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.common.js.ejs
@@ -4,15 +4,27 @@ const { merge } = require('webpack-merge');
 const { VueLoaderPlugin } = require('vue-loader');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 <%_ if (enableTranslation) { _%>
+const { hashElement } = require('folder-hash');
 const MergeJsonWebpackPlugin = require('merge-jsons-webpack-plugin');
 <%_ } _%>
+const { DefinePlugin } = require('webpack');
 const vueLoaderConfig = require('./loader.conf');
 
 function resolve(dir) {
   return path.join(__dirname, '..', dir);
 }
 
-module.exports = env => merge(
+module.exports = async env => {
+<%_ if (enableTranslation) { _%>
+  const languagesHash = await hashElement(path.resolve(__dirname, '../<%= MAIN_SRC_DIR %>i18n'), {
+    algo: 'md5',
+    encoding: 'hex',
+    files: { include: ['*.json'] },
+  });
+
+<%_ } _%>
+
+  return merge(
 {
   mode: 'development',
   context: path.resolve(__dirname, '../'),
@@ -104,6 +116,12 @@ module.exports = env => merge(
     ]
   },
   plugins: [
+    new DefinePlugin({
+<%_ if (enableTranslation) { _%>
+      I18N_HASH: JSON.stringify(languagesHash.hash),
+<%_ } _%>
+      'process.env': require(env.env == 'development' ? './dev.env' : './prod.env'),
+    }),
     new VueLoaderPlugin(),
     new CopyWebpackPlugin({
       patterns: [
@@ -136,3 +154,4 @@ module.exports = env => merge(
 }
 // jhipster-needle-add-webpack-config - JHipster will add custom config
 );
+};

--- a/generators/client/templates/vue/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.dev.js.ejs
@@ -29,7 +29,7 @@ const commonConfig = require('./webpack.common');
 const jhiUtils = require('./utils.js');
 const MODE = 'development';
 
-module.exports = env => webpackMerge(commonConfig({ env: MODE }), {
+module.exports = async env => webpackMerge(await commonConfig({ env: MODE }), {
   mode: MODE,
   module: {
     rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap, usePostCSS: true })
@@ -87,9 +87,6 @@ module.exports = env => webpackMerge(commonConfig({ env: MODE }), {
     historyApiFallback: true
   },
   plugins: [
-    new webpack.DefinePlugin({
-      'process.env': require('./dev.env')
-    }),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
     new HtmlWebpackPlugin({

--- a/generators/client/templates/vue/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.prod.js.ejs
@@ -31,7 +31,6 @@ const config = require('./env');
 const baseWebpackConfig = require('./webpack.common');
 const jhiUtils = require('./utils.js');
 
-const env = require('./prod.env');
 const MODE = 'production';
 
 const webpackConfig = {
@@ -72,10 +71,6 @@ const webpackConfig = {
     }
   },
   plugins: [
-    // http://vuejs.github.io/vue-loader/en/workflow/production.html
-    new webpack.DefinePlugin({
-      'process.env': env
-    }),
     new TerserPlugin({
       terserOptions: {
         compress: {
@@ -175,4 +170,4 @@ if (config.build.bundleAnalyzerReport) {
   webpackConfig.plugins.push(new BundleAnalyzerPlugin());
 }
 
-module.exports = webpackMerge(baseWebpackConfig({ env: MODE }), webpackConfig);
+module.exports = async () => webpackMerge(await baseWebpackConfig({ env: MODE }), webpackConfig);


### PR DESCRIPTION
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
